### PR TITLE
Update .jscsrc

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -53,7 +53,7 @@
     "disallowSpacesInsideArrayBrackets": "all",
     "disallowSpacesInsideParentheses": true,
 
-    "validateJSDoc": {
+    "jsDoc": {
         "checkParamNames": true,
         "requireParamTypes": true
     },


### PR DESCRIPTION
Was getting 'unsupported rule:validateJSDoc'.  validateJSDOC deprecated in favor of jsDoc.
