### PR TITLE
validateJSDoc was deprecated, is now jsDoc

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -53,7 +53,7 @@
     "disallowSpacesInsideArrayBrackets": "all",
     "disallowSpacesInsideParentheses": true,
 
-    "validateJSDoc": {
+    "jsDoc": {
         "checkParamNames": true,
         "requireParamTypes": true
     },


### PR DESCRIPTION
https://github.com/roots/sage/issues/1521
