### PR TITLE
"validateJSDoc" deprecated, use "jsDoc" instead

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -53,9 +53,12 @@
     "disallowSpacesInsideArrayBrackets": "all",
     "disallowSpacesInsideParentheses": true,
 
-    "validateJSDoc": {
+    "jsDoc": {
+        "checkAnnotations": true,
         "checkParamNames": true,
-        "requireParamTypes": true
+        "requireParamTypes": true,
+        "checkReturnTypes": true,
+        "checkTypes": true
     },
 
     "disallowMultipleLineBreaks": true,


### PR DESCRIPTION
updated to use a non-depreacted property
