### PR TITLE
Changed bootstrap version from ~3.3.1 to 3.3.4

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "jquery": "~2.1.1",
     "angular": "~1.3.8",
     "angular-sanitize": "~1.3.8",
-    "bootstrap": "~3.3.1",
+    "bootstrap": "3.3.4",
     "extras.angular.plus": "~0.9.2",
     "font-awesome": "~4.2.0",
     "moment": "~2.8.4",


### PR DESCRIPTION
I was following the videos and could not figure out why bootstrap css was not injected into HTML. Here is the issue:
https://github.com/twbs/bootstrap/issues/16663